### PR TITLE
Fix linking on SmartOS/Illumos/Solaris.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 {port_env, [
   {"DRV_LDFLAGS","-shared $ERL_LDFLAGS -lpthread"},
   {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
-  {"solaris", "ERL_LDFLAGS", "-lnsl $ERL_LDFLAGS"},
+  {"solaris", "ERL_LDFLAGS", "-lssp -lnsl $ERL_LDFLAGS"},
   {"DRV_CFLAGS","-Ic_src -Wall -fPIC $ERL_CFLAGS"},
   {"LDFLAGS", "$LDFLAGS -lpthread"}
 ]}.


### PR DESCRIPTION
In addition to the changes discussed in #2 manually specifying lib stack smashing protector (-lssp) as ld flag is needed to build bcrypt on SmartOS. Seems to be the issue described [here](https://www.illumos.org/issues/5788):

> It kind of does cause problems. If you pass -fstack-protector when compiling libssp gets linked in automatically, but if you are building objects separately and then do the final link with ld libssp does not get linked in, and you get unresolved symbol errors. The solution is to make sure that -lssp is passed when linking with ld. Linux (and BSD, afaik) include SSP support directly in libc so there's no need to futz with the separate libssp library.

Not sure why @Licenser didn't run into this problem when he created #2. I've used both the SmartOS 16.4.1 (LTS) and 17.2.0 (latest) versions and ran in to this problem.