### PR TITLE
Make bcrypt twice faster with -O2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
   {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
   {"solaris", "ERL_LDFLAGS", "-lssp -lnsl $ERL_LDFLAGS"},
   {"DRV_CFLAGS","-Ic_src -Wall -fPIC $ERL_CFLAGS"},
+  {"CFLAGS", "$CFLAGS -O2"},
   {"LDFLAGS", "$LDFLAGS -lpthread"}
 ]}.
 


### PR DESCRIPTION
Before:
```
1> {ok, S} = bcrypt:gen_salt().
2> timer:tc(fun bcrypt:hashpw/2, ["foo", S]).
{583350, {ok,"$2a$12$KGDV3lQV4Q9RasBvnDLv1eWsS8.dlQA7JRP3ldoh3fNrseGI4zzP2"}}
```

After:
```
1> {ok, S} = bcrypt:gen_salt().
2> timer:tc(fun bcrypt:hashpw/2, ["foo", S]).
{284084, {ok,"$2a$12$ta6Uz873HOhJGvwb64jdpOSgbenQwECZzs/ag2kf3EX..17Z3ijSS"}}
```

  