### PR TITLE
Make bcrypt twice faster

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
   {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
   {"solaris", "ERL_LDFLAGS", "-lssp -lnsl $ERL_LDFLAGS"},
   {"DRV_CFLAGS","-Ic_src -Wall -fPIC $ERL_CFLAGS"},
+  {"CFLAGS", "$CFLAGS -O2"},
   {"LDFLAGS", "$LDFLAGS -lpthread"}
 ]}.
 


### PR DESCRIPTION
```erlang
> S = "$2a$12$6gGcgnW/qDv8sCZ6Bj1qj.ZOpk.64CBYO5C1aPY9UIUs5TcmyykKC".

> timer:tc(bcrypt, hashpw, [S, S]).
{790990,
 {ok,"$2a$12$6gGcgnW/qDv8sCZ6Bj1qj.ZOpk.64CBYO5C1aPY9UIUs5TcmyykKC"}}

%% vs 

> timer:tc(bcrypt, hashpw, [S, S]).
{348747,
 {ok,"$2a$12$6gGcgnW/qDv8sCZ6Bj1qj.hPVEhC7j/NCGywUpw.nfmHlJmXMQ.Li"}}
```