### PR TITLE
Fix linking on newer SmartOS versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 {port_env, [
   {"DRV_LDFLAGS","-shared $ERL_LDFLAGS -lpthread"},
   {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
-  {"solaris", "ERL_LDFLAGS", "-lssp -lnsl $ERL_LDFLAGS"},
+  {"solaris", "ERL_LDFLAGS", "-lxnet -lssp -lnsl $ERL_LDFLAGS"},
   {"DRV_CFLAGS","-Ic_src -Wall -fPIC $ERL_CFLAGS"},
   {"LDFLAGS", "$LDFLAGS -lpthread"}
 ]}.


### PR DESCRIPTION
Newer SmartOS versions require the 'xnet' library to be explicitly declared to the linker. While this might not be needed on plain Solaris this is good form non the less (since bcrypt uses symbols from the net library).