### PR TITLE
Rename function to avoid clash with OpenBSD's native bcrypt.

### DIFF
--- a/c_src/bcrypt.c
+++ b/c_src/bcrypt.c
@@ -63,7 +63,7 @@
 #define BCRYPT_BLOCKS 6		/* Ciphertext blocks */
 #define BCRYPT_MINROUNDS 16	/* we have log2(rounds) in salt */
 
-int bcrypt(char *, const char *, const char *);
+int ts_bcrypt(char *, const char *, const char *);
 void encode_salt(char *, u_int8_t *, u_int16_t, u_int8_t);
 
 static void encode_base64(u_int8_t *, u_int8_t *, u_int16_t);
@@ -143,7 +143,7 @@ encode_salt(char *salt, u_int8_t *csalt, u_int16_t clen, u_int8_t logr)
    i.e. $2$04$iwouldntknowwhattosayetKdJ6iFtacBqJdKe6aW7ou */
 
 int
-bcrypt(char * encrypted, const char *key, const char *salt)
+ts_bcrypt(char * encrypted, const char *key, const char *salt)
 {
 	blf_ctx state;
 	u_int32_t rounds, i, k;

--- a/c_src/bcrypt_nif.c
+++ b/c_src/bcrypt_nif.c
@@ -87,7 +87,7 @@ static ERL_NIF_TERM hashpw(task_t* task)
         salt_sz = task->data.hash.salt.size;
     (void)memcpy(&salt, task->data.hash.salt.data, salt_sz);
 
-    if (bcrypt(encrypted, password, salt)) {
+    if (ts_bcrypt(encrypted, password, salt)) {
         return enif_make_tuple3(
             task->env,
             enif_make_atom(task->env, "error"),

--- a/c_src/bcrypt_nif.h
+++ b/c_src/bcrypt_nif.h
@@ -5,7 +5,7 @@
 
 typedef unsigned char byte;
 
-int bcrypt(char *, const char *, const char *);
+int ts_bcrypt(char *, const char *, const char *);
 void encode_salt(char *, u_int8_t *, u_int16_t, u_int8_t);
 
 typedef struct {

--- a/c_src/bcrypt_port.c
+++ b/c_src/bcrypt_port.c
@@ -35,7 +35,7 @@
 
 typedef unsigned char byte;
 
-char *bcrypt(char *, const char *, const char *);
+int ts_bcrypt(char *, const char *, const char *);
 void encode_salt(char *, u_int8_t *, u_int16_t, u_int8_t);
 
 /* These methods came from the Erlang port command tutorial:
@@ -168,7 +168,7 @@ process_hashpw(ETERM *pid, ETERM *data)
         } else {
             memcpy(password, ERL_BIN_PTR(pwd_bin), ERL_BIN_SIZE(pwd_bin));
             memcpy(salt, ERL_BIN_PTR(slt_bin), ERL_BIN_SIZE(slt_bin));
-            if (bcrypt(encrypted, password, salt)) {
+            if (ts_bcrypt(encrypted, password, salt)) {
                 retval = process_reply(pid, CMD_HASHPW, "Invalid salt");
             } else {
                 retval = process_reply(pid, CMD_HASHPW, encrypted);


### PR DESCRIPTION
OpenBSD provides its own declaration for function bcrypt in
pwd.h. This conflicts with the changes introduced in commits
1277ee41bba86d47e039e3f24a47a491efe48d78 and
ce7523f34b9b2b18c76490ffbb832a54603f7a55.

Renaming the function to "ts_bcrypt" ("thread safe bcrypt") avoids
this. Additionally, in bcrypt_port.c, the return type was still the
original char *, changed this to type int to match the function
definition in bcrypt.c.