### PR TITLE
Remove erl_interface. Use rebar3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ priv/bcrypt
 priv/bcrypt_nif.so
 logs/*
 .eunit
+rebar3
+.rebar
 
 ## libtool
 .deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: erlang
 sudo: false
 otp_release:
-  - 20.0
+  - 23.0
+  - 22.3
+  - 21.3
+  - 20.3
   - 19.3
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,11 @@ otp_release:
   - 23.0
   - 22.3
   - 21.3
-  - 20.3
-  - 19.3
 
 jobs:
   include:
     - stage: deploy
-      otp_release: 19.3
+      otp_release: 22.3
       script: skip
       deploy:
         provider: script

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,21 @@
-all: compile
-
-compile:
-	@rebar compile
-
-tests:
-	@rebar eunit
-
-clean:
-	@rebar clean
+REBAR := $(shell which rebar3 2>/dev/null || echo ./rebar3)
+REBAR_URL := https://s3.amazonaws.com/rebar3/rebar3
 
 .PHONY: clean compile tests
+
+all: compile
+
+compile: $(REBAR)
+	$(REBAR) compile
+
+tests: $(REBAR)
+	$(REBAR) eunit
+
+clean: $(REBAR)
+	$(REBAR) clean
+
+./rebar3:
+	erl -noshell -s inets start -s ssl start \
+		-eval '{ok, saved_to_file} = httpc:request(get, {"$(REBAR_URL)", []}, [], [{stream, "./rebar3"}])' \
+		-s inets stop -s init stop
+	chmod +x ./rebar3

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -23,17 +23,16 @@ UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -Wall
 	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
-	DRV_LDFLAGS = -flat_namespace -undefined suppress $(ERL_LDFLAGS) -lpthread
+	DRV_LDFLAGS = -flat_namespace -undefined suppress $(ERL_LDFLAGS)
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -lpthread
-	CXXFLAGS ?= -O3 -Wall
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	DRV_LDFLAGS = $(ERL_LDFLAGS)
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -lpthread
-	CXXFLAGS ?= -O3 -Wall
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	DRV_LDFLAGS = $(ERL_LDFLAGS)
 endif
 
 #   {"DRV_LDFLAGS","-shared $ERL_LDFLAGS -lpthread"},
@@ -44,10 +43,8 @@ endif
 #   {"LDFLAGS", "$LDFLAGS -lpthread"}
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
-CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
-LD_FLAGS += -lpthread
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei -lpthread
 
 # Verbosity.
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,9 +1,92 @@
-compile: ../priv/bcrypt
+# Based on c_src.mk from erlang.mk by Loic Hoguin <essen@ninenines.eu>
 
-../priv/bcrypt:
-	$(CC) $(CFLAGS) $(ERL_CFLAGS) $(EXE_LDFLAGS) bcrypt_port.c bcrypt.o blowfish.o $(LDFLAGS) $(ERL_LDFLAGS) -lpthread -o ../priv/bcrypt
+CURDIR := $(shell pwd)
+BASEDIR := $(abspath $(CURDIR)/..)
+
+PROJECT ?= $(notdir $(BASEDIR))
+PROJECT := $(strip $(PROJECT))
+
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+
+C_SRC_DIR = $(CURDIR)
+C_SRC_NIF = $(CURDIR)/../priv/bcrypt_nif.so
+C_SRC_PORT = $(CURDIR)/../priv/bcrypt
+
+# DRV_LDFLAGS = -shared $(ERL_LDFLAGS) -lpthread
+DRV_CFLAGS = -Ic_src -Wall -O3 -fPIC $(ERL_CFLAGS)
+
+# System type and C compiler/flags.
+
+UNAME_SYS := $(shell uname -s)
+ifeq ($(UNAME_SYS), Darwin)
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch x86_64 -Wall
+	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	DRV_LDFLAGS = -flat_namespace -undefined suppress $(ERL_LDFLAGS) -lpthread
+else ifeq ($(UNAME_SYS), FreeBSD)
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -Wall
+else ifeq ($(UNAME_SYS), Linux)
+	CC ?= gcc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -Wall
+endif
+
+#   {"DRV_LDFLAGS","-shared $ERL_LDFLAGS -lpthread"},
+#   {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
+#   {"solaris", "ERL_LDFLAGS", "-lxnet -lssp -lnsl $ERL_LDFLAGS"},
+#   {"DRV_CFLAGS","-Ic_src -Wall -O3 -fPIC $ERL_CFLAGS"},
+#   {"CFLAGS", "$CFLAGS -Ic_src -Wall -O3"},
+#   {"LDFLAGS", "$LDFLAGS -lpthread"}
+
+CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+
+LD_FLAGS += -lpthread
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei
+
+# Verbosity.
+
+c_verbose_0 = @echo " C     " $(?F);
+c_verbose = $(c_verbose_$(V))
+
+cpp_verbose_0 = @echo " CPP   " $(?F);
+cpp_verbose = $(cpp_verbose_$(V))
+
+link_verbose_0 = @echo " LD    " $(@F);
+link_verbose = $(link_verbose_$(V))
+
+SOURCES := $(shell find $(C_SRC_DIR) -type f \( -name "*.c" -o -name "*.C" -o -name "*.cc" -o -name "*.cpp" \))
+OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
+
+COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
+COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
+
+all: $(C_SRC_NIF) $(C_SRC_PORT)
+
+$(C_SRC_PORT): $(OBJECTS)
+	@mkdir -p $(BASEDIR)/priv/
+	$(CC) $(CFLAGS) bcrypt_port.o bcrypt.o blowfish.o $(DRV_LDFLAGS) $(LDLIBS) -o ../priv/bcrypt
+
+$(C_SRC_NIF): $(OBJECTS)
+	@mkdir -p $(BASEDIR)/priv/
+	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) -shared $(LDLIBS) -o $(C_SRC_NIF)
+
+%.o: %.c
+	$(COMPILE_C) $(OUTPUT_OPTION) $<
+
+%.o: %.cc
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.C
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.cpp
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
 clean:
-	@rm -f ../priv/bcrypt
-
-.PHONY: clean compile
+	@rm -f $(C_SRC_OUTPUT) $(OBJECTS)

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -28,11 +28,11 @@ ifeq ($(UNAME_SYS), Darwin)
 	DRV_LDFLAGS = -flat_namespace -undefined suppress $(ERL_LDFLAGS) -lpthread
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -lpthread
 	CXXFLAGS ?= -O3 -Wall
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -lpthread
 	CXXFLAGS ?= -O3 -Wall
 endif
 

--- a/c_src/bcrypt_nif.c
+++ b/c_src/bcrypt_nif.c
@@ -24,14 +24,14 @@
 #include "erl_blf.h"
 #include "bcrypt_nif.h"
 
-void free_task(task_t* task)
+static void free_task(task_t* task)
 {
     if (task->env != NULL)
         enif_free_env(task->env);
     enif_free(task);
 }
 
-task_t* alloc_task(task_type_t type)
+static task_t* alloc_task(task_type_t type)
 {
     task_t* task = (task_t*)enif_alloc(sizeof(task_t));
     if (task == NULL)
@@ -41,7 +41,7 @@ task_t* alloc_task(task_type_t type)
     return task;
 }
 
-task_t* alloc_init_task(task_type_t type, ERL_NIF_TERM ref, ErlNifPid pid, int num_orig_terms, const ERL_NIF_TERM orig_terms[])
+static task_t* alloc_init_task(task_type_t type, ERL_NIF_TERM ref, ErlNifPid pid, int num_orig_terms, const ERL_NIF_TERM orig_terms[])
 {
     task_t* task = alloc_task(type);
     task->pid = pid;
@@ -102,7 +102,7 @@ static ERL_NIF_TERM hashpw(task_t* task)
         enif_make_string(task->env, encrypted, ERL_NIF_LATIN1));
 }
 
-void* async_worker(void* arg)
+static void* async_worker(void* arg)
 {
     ctx_t* ctx;
     task_t* task;

--- a/rebar.config
+++ b/rebar.config
@@ -1,39 +1,10 @@
 %% -*- mode: erlang;erlang-indent-level: 2;indent-tabs-mode: nil -*-
 %% {erl_opts, [debug_info]}.
 
-%% {so_specs,
-%%  [{"priv/bcrypt_nif.so",
-%%    ["c_src/*.c"]}]}.
-{port_env, [
-  {"DRV_LDFLAGS","-shared $ERL_LDFLAGS -lpthread"},
-  {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
-  {"solaris", "ERL_LDFLAGS", "-lxnet -lssp -lnsl $ERL_LDFLAGS"},
-  {"DRV_CFLAGS","-Ic_src -Wall -fPIC $ERL_CFLAGS"},
-  {"CFLAGS", "$CFLAGS -O2"},
-  {"LDFLAGS", "$LDFLAGS -lpthread"}
-]}.
+{pre_hooks,
+  [{"(linux|darwin|solaris)", compile, "make -C c_src"},
+   {"(freebsd)", compile, "gmake -C c_src"}]}.
 
-{port_specs, [
-    {"priv/bcrypt_nif.so", ["c_src/*.c"]},
-    {"priv/bcrypt", [
-        "c_src/bcrypt_port.c",
-        "c_src/bcrypt.c",
-        "c_src/blowfish.c"
-    ]}
-]}.
-
-%% These post_hooks are for rebar2. rebar.config.script removes them if
-%% rebar3 is detected
 {post_hooks,
- [{clean, "make -C c_src clean"},
-  {compile, "make -C c_src"}]}.
-
-%% plugins and provider_hooks are for rebar3. rebar.config.script removes them
-%% if rebar2 is detected
-{plugins, [pc]}.
-{provider_hooks, [
-  {pre, [
-    {compile, {pc, compile}},
-    {clean, {pc, clean}}
-  ]}
-]}.
+  [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
+   {"(freebsd)", clean, "gmake -C c_src clean"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,9 @@
 %% -*- mode: erlang;erlang-indent-level: 2;indent-tabs-mode: nil -*-
-%% {erl_opts, [debug_info]}.
+
+{require_min_otp_vsn, "21"}.
+
+{erl_opts,
+  [debug_info]}.
 
 {pre_hooks,
   [{"(linux|darwin|solaris)", compile, "make -C c_src"},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,0 @@
-case code:is_loaded(rebar3) of
-  false ->
-    C1 = proplists:delete(plugins, CONFIG),
-    proplists:delete(provider_hooks, C1);
-  {file, _} ->
-    proplists:delete(post_hooks, CONFIG)
-end.

--- a/src/bcrypt.erl
+++ b/src/bcrypt.erl
@@ -8,16 +8,31 @@
 -export([mechanism/0]).
 -export([gen_salt/0, gen_salt/1, hashpw/2]).
 
+-type mechanism() :: nif | port.
+-type rounds() :: 4..31.
+-type pwerr() :: invalid_salt | invalid_salt_length | invalid_rounds.
+
+-export_type([ mechanism/0, rounds/0, pwerr/0 ]).
+
 start() -> application:start(bcrypt).
 stop()  -> application:stop(bcrypt).
 
+-spec mechanism() -> mechanism().
 mechanism() ->
     {ok, M} = application:get_env(bcrypt, mechanism),
     M.
 
-gen_salt() -> do_gen_salt(mechanism()).
-gen_salt(Rounds) -> do_gen_salt(mechanism(), Rounds).
-hashpw(Password, Salt) -> do_hashpw(mechanism(), Password, Salt).
+-spec gen_salt() -> {ok, string()}.
+gen_salt() ->
+    do_gen_salt(mechanism()).
+
+-spec gen_salt( rounds() ) -> {ok, string()}.
+gen_salt(Rounds) ->
+    do_gen_salt(mechanism(), Rounds).
+
+-spec hashpw( string() | binary(), string() | binary() ) -> {ok, string()} | {error, pwerr()}.
+hashpw(Password, Salt) ->
+    do_hashpw(mechanism(), Password, Salt).
 
 do_gen_salt(nif)  -> bcrypt_nif_worker:gen_salt();
 do_gen_salt(port) -> bcrypt_pool:gen_salt().

--- a/test/bcrypt_tests.erl
+++ b/test/bcrypt_tests.erl
@@ -108,8 +108,12 @@ simple_nif_test_() ->
 
 pair_nif_test_() ->
     {setup, fun() -> ok = start_with(nif) end,
-     [?_assert({ok, Hash} =:= bcrypt:hashpw(Pass, Salt)) ||
-         {Pass, Salt, Hash} <- ?PAIRS]}.
+     [
+        begin
+            ?_assert({ok, Hash} =:= bcrypt:hashpw(Pass, Salt))
+        end
+        || {Pass, Salt, Hash} <- ?PAIRS
+     ]}.
 
 simple_port_test_() ->
     {setup, fun() -> ok = start_with(port) end,
@@ -123,5 +127,9 @@ simple_port_test_() ->
 
 pair_port_test_() ->
     {setup, fun() -> ok = start_with(port) end,
-     [?_assert({ok, Hash} =:= bcrypt:hashpw(Pass, Salt)) ||
-         {Pass, Salt, Hash} <- ?PAIRS]}.
+     [
+        begin
+            ?_assert({ok, Hash} =:= bcrypt:hashpw(Pass, Salt))
+        end
+        || {Pass, Salt, Hash} <- ?PAIRS
+     ]}.


### PR DESCRIPTION
Fix #9 


This removes support for OTP-19 and 21.
As those don't seem to have the newer `ei` functions.
