### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,11 +7,11 @@
 
 {pre_hooks,
   [{"(linux|darwin|solaris)", compile, "make -C c_src"},
-   {"(freebsd)", compile, "gmake -C c_src"}]}.
+   {"(freebsd|openbsd)", compile, "gmake -C c_src"}]}.
 
 {post_hooks,
   [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
-   {"(freebsd)", clean, "gmake -C c_src clean"}]}.
+   {"(freebsd|openbsd)", clean, "gmake -C c_src clean"}]}.
 {deps, [
   {poolboy, "1.5.2"}
 ]}.


### PR DESCRIPTION
Dear author
The bcrypt's c_src can not be build on OpenBSD.
I find the OpenBSD platform is missing in rebar.config.
So I add the identify in rebar.config.

Thanks & Regards
David Gao
