### PR TITLE
Remove specifying the arch for which is built

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -22,8 +22,7 @@ DRV_CFLAGS = -Ic_src -Wall -O3 -fPIC $(ERL_CFLAGS)
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
-	LDFLAGS ?= -arch x86_64
+	CFLAGS ?= -O3 -std=c99 -Wall -Wmissing-prototypes
 	LDFLAGS += -flat_namespace -undefined suppress
 	DRV_LDFLAGS = -flat_namespace -undefined suppress $(ERL_LDFLAGS)
 else ifeq ($(UNAME_SYS), Linux)


### PR DESCRIPTION
This PR removes the hard coded `arch` for which is built. When the user compiles on a M1 powered Mac, the built will be either a `x86_64` or an `arm64`, depending on the current arch in the users terminal.

It is possible to check this with the `arch` command. The architecture of the underlying erlang system must be the same as the one in the terminal where the built is run.  

I don't know a good way to determine the architecture of the underlying erlang system. If that is possible, the builds architecture  could be set to the architecture of the erlang system, not of the terminal. This PR assumes the architecture of the terminal is the same as the erlang system, which is usually the case.

Fixes #20