### PR TITLE
Fix a problem where compilation failed if bcrypt abspath has spaces in it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [21.3,22.3,23]
+        otp_version: [21.3, 22.3, 23, 24]
         os: [ubuntu-latest]
 
     container:

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,7 +1,7 @@
 # Based on c_src.mk from erlang.mk by Loic Hoguin <essen@ninenines.eu>
 
-CURDIR := $(shell pwd)
-BASEDIR := $(abspath $(CURDIR)/..)
+CURDIR := .
+BASEDIR := ..
 
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))


### PR DESCRIPTION
If the path to the bcrypt checkout has spaces in it, then the compilation failed due to the use of non-escaped absolute paths in the compilation commands.