### PR TITLE
Fix Poolboy start_link params

### DIFF
--- a/src/bcrypt_nif_pool_sup.erl
+++ b/src/bcrypt_nif_pool_sup.erl
@@ -15,8 +15,8 @@ init([]) ->
 
     PoolArgs = [
         {name, {local, bcrypt_nif_pool}},
-        {nif_pool_size, PoolSize},
-        {nif_pool_max_overflow, MaxOverFlow},
+        {size, PoolSize},
+        {max_overflow, MaxOverFlow},
         {worker_module, bcrypt_nif_worker}
     ],
 


### PR DESCRIPTION
The values passed from the NIF pool supervisor to Poolboy's start_link have the wrong name and are ignored. This patch renames them to the correct names.

See: https://github.com/devinus/poolboy/blob/master/src/poolboy.erl#L157-L160