### PR TITLE
Fix typo in Makefile preventing `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REBAR := $(shell which rebar3 2>/dev/null || echo ./rebar3)
 REBAR_URL := https://s3.amazonaws.com/rebar3/rebar3
 
-.PHONY: clean compile tests
+.PHONY: clean compile test
 
 all: compile
 


### PR DESCRIPTION
This is just a quick fix to the makefile where `make test` always just says "test is up to date" because the .PHONY has "tests" instead of "test."