### PR TITLE
Fix Makefile issue

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,9 +6,9 @@ BASEDIR := ..
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]), halt().")
-ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]), halt().")
-ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]), halt().")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval 'io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).' -s erlang halt)
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -eval 'io:format("~s", [code:lib_dir(erl_interface, include)]).' -s erlang halt)
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -eval 'io:format("~s", [code:lib_dir(erl_interface, lib)]).' -s erlang halt)
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_NIF = $(CURDIR)/../priv/bcrypt_nif.so


### PR DESCRIPTION
This PR fixes an issue using `bcrypt` in a GitHub Action/Docker Container.

[This issue](https://github.com/zotonic/zotonic/issues/3734) describes the error:
```shell
make[1]: Entering directory '/tmp/zotonic/_build/default/lib/bcrypt/c_src'
Error! Failed to eval: io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).

Error! Failed to eval: io:format("~s", [code:lib_dir(erl_interface, include)]).

cc -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes -D_DEFAULT_SOURCE -fPIC -I  -I   -c -o bcrypt_nif.o bcrypt_nif.c
bcrypt_nif.c:23:10: fatal error: erl_nif.h: No such file or directory
   23 | #include "erl_nif.h"
      |          ^~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:77: bcrypt_nif.o] Error 1
make[1]: Leaving directory '/tmp/zotonic/_build/default/lib/bcrypt/c_src'
===> Hook for compile failed!

make: *** [GNUmakefile:37: compile] Error 1
Error: Process completed with exit code 2.
```

Using the changes of this PR, [no error is raised](https://github.com/williamthome/z_ci/actions/runs/8793366759/job/24131233432?pr=1). Those changes are based on [this issue](https://github.com/erlang/otp/issues/6916).